### PR TITLE
Cleaned up version of TF-IDF calculation that runs on AWS

### DIFF
--- a/day5/mr_tfidf_per_sender_aws.py
+++ b/day5/mr_tfidf_per_sender_aws.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+
+from cStringIO import StringIO
+
+from mrjob.protocol import JSONValueProtocol
+from mrjob.job import MRJob
+from mrjob.emr import EMRJobRunner
+
+from term_tools import get_terms
+
+class MRTFIDFBySender(MRJob):
+    INPUT_PROTOCOL = JSONValueProtocol
+    OUTPUT_PROTOCOL = JSONValueProtocol
+
+    def configure_options(self):
+        super(MRTFIDFBySender, self).configure_options()
+        self.add_passthrough_option(
+            '--idf_loc', type='str', default='',
+            help='The s3:// URL for the location of the IDFs')
+        self.add_passthrough_option(
+            '--aws_access_key_id', type='str', default='',
+            help='The access key ID for the AWS account')
+        self.add_passthrough_option(
+            '--aws_secret_access_key', type='str', default='',
+            help='The secret access key for the AWS account')
+
+    def mapper(self, key, email):
+        for term in get_terms(email['text']):
+            yield {'term': term, 'sender': email['sender']}, 1
+
+    def reducer_init(self):
+        self.idfs = {}
+
+        # Iterate through the files in the bucket provided by the user
+        if self.options.aws_access_key_id and self.options.aws_secret_access_key:
+            emr = EMRJobRunner(aws_access_key_id=self.options.aws_access_key_id,
+                               aws_secret_access_key=self.options.aws_secret_access_key)
+        else:
+            emr = EMRJobRunner()
+
+        for key in emr.get_s3_keys("s3://" + self.options.idf_loc):
+            # Load the whole file first, then read it line-by-line: otherwise,
+            # chunks may not be even lines
+            for line in StringIO(key.get_contents_as_string()): 
+                term_idf = JSONValueProtocol.read(line)[1] # parse the line as a JSON object
+                self.idfs[term_idf['term']] = term_idf['idf']
+
+    def reducer(self, term_sender, howmany):
+        tfidf = sum(howmany) * self.idfs[term_sender['term']]
+        yield None, {'sender': term_sender['sender'], 'term': term_sender['term'], 'tfidf': tfidf}
+
+if __name__ == '__main__':
+        MRTFIDFBySender.run()


### PR DESCRIPTION
It's not quite as clean as I wanted to make it, and there are a few things to note:
- The code should be invoked something like this:

``` sh
python mr_tfidf_per_sender_aws.py \
  -r emr --num-ec2-instances=40 \
  --python-archive=package.tar.gz \
  -o 's3://dataiap-wolfsonm-student55-testbucket/tf_idfs_clean' \
  --no-output \
  --idf_loc='dataiap-wolfsonm-student55-testbucket/idf_parts' \
  --aws_access_key_id=$AWS_ACCESS_KEY_ID \
  --aws_secret_access_key=$AWS_SECRET_ACCESS_KEY \
  's3://dataiap-enron-json/*.json'
```
- You _cannot_ have `s3://` in the  `--idf_loc` argument. I'm not sure why: I think it's because then, `mrjob` treats it like some file that it tries to load for you automatically and fails. Debugging this took _hours_, and I couldn't believe what the final solution was.
- There's still no way to get the access key id and secret access key onto the node, since the environment changes. It may be cleaner to do it with the `mrjob.conf` file, but that doesn't work for our purposes either. Anyway, what I've done is kind of a hack, but it works fine and is flexible enough to work. The only thing that's really "broken" about the code is that there are parameters that are really required which are passed in as arguments (ostensibly optional).
- No need to add `boto` to the `package.tar.gz`
